### PR TITLE
Fix #4; Adjust default parallel job based on CPU count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,46 @@
+# Project related
+mk
+
+# Go related
+
+# Java related
+pom.xml
+*.class
+
+# Python
+*.pyc
+*.pyo
+/__pycache__/
+
+# Ruby
+#Gemfile.lock
+.sass-cache/
+
+# Temp Files
+*.orig
+*~
+.*.swp
+.*.swo
+*.tmp
+*.bak
+
+# Editors (IntelliJ / Eclipse)
+*/.idea
+.idea
+*/.classpath
+.classpath
+*/.project
+.project
+*/.settings
+.settings
+
+# OS X
+.DS_Store
+
+# Logging
+*.log
+/logs/
+
+# Builds
+*.o
+out/

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Mk is a reboot of the Plan 9 mk command, which itself is [a successor to
 make](http://www.cs.tufts.edu/~nr/cs257/archive/andrew-hume/mk.pdf). This tool
 is for anyone who loves make, but hates all its stupid bullshit.
 
-# Installation
+## Installation
 
  1. Install Go.
  2. Run `go get github.com/dcjones/mk`
  3. Make sure `$GOPATH/bin` is in your `PATH`.
 
-# Why Plan 9 mk is better than make
+## Why Plan 9 mk is better than make
 
 Way back in the 90s, some smart guys at Bell Labs got together and decided to
 write new operating system to replace Unix. The idea was to keep everything that
@@ -43,13 +43,14 @@ elegant, and powerful. To name a few specifics:
      `<|sh config.sh`.
   1. A generalized mechanism to determine if a target is out of date, for when
      timestamps won't cut it.
-  1. Variables are expanded in recipes only if they are defined. They way you
+  1. Variables are expanded in recipes only if they are defined. That way you
      usually don't have to escape `$`.
 
-And much more! Read [Maintaining Files on Plan 9 with
-Mk](http://doc.cat-v.org/plan_9/4th_edition/papers/mk) for good overview.
+And much more!
+Read [Maintaining Files on Plan 9 with Mk](http://doc.cat-v.org/plan_9/4th_edition/papers/mk)
+for good overview.
 
-# Improvements over Plan 9 mk
+## Improvements over Plan 9 mk
 
 This mk stays mostly faithful to Plan 9, but makes a few (in my opinion)
 improvements.
@@ -72,21 +73,21 @@ improvements.
   1. Pretty colors.
 
 
-# Usage
+## Usage
 
 `mk [options] [target] ...`
 
-## Options
+### Options
 
   * `-f filename` Use the given file as the mkfile.
   * `-n` Dry run, print commands without actually executing.
   * `-r` Force building of the immediate targets.
   * `-a` Force building the targets and of all their dependencies.
-  * `-p` Maximum number of jobs to execute in parallel (default: 8)
+  * `-p` Maximum number of jobs to execute in parallel (default: # CPU cores)
   * `-i` Show rules that will execute and prompt before executing.
 
 
-# Non-shell recipes
+## Non-shell recipes
 
 Non-shell recipes are a major addition over Plan 9 mk. They can be used with the
 `S[command]` attribute, where `command` is an arbitrary command that the recipe
@@ -100,7 +101,7 @@ mean.txt:Sjulia: input.txt
             mean(map(parseint, eachline(open("$prereq")))))
 ```
 
-# Current State
+## Current State
 
 Functional, but with some bugs and some unimplemented minor features. Give it a
 try and see what you think!

--- a/README.md
+++ b/README.md
@@ -106,4 +106,10 @@ mean.txt:Sjulia: input.txt
 Functional, but with some bugs and some unimplemented minor features. Give it a
 try and see what you think!
 
+## License
+
+This work is provided under the [BSD 2-clause](https://opensource.org/licenses/BSD-2-Clause) license.
+
+Copyright (c) 2013, [Daniel C. Jones](https://github.com/dcjones) - All rights reserved.
+Updates made by [Paul deGrandis](https://github.com/ohpauleez) Feb 2016.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ is for anyone who loves make, but hates all its stupid bullshit.
  2. Run `go get github.com/dcjones/mk`
  3. Make sure `$GOPATH/bin` is in your `PATH`.
 
+### Building/installing from source
+
+ 1. `git clone` the repo
+ 2. `go build`
+
 ## Why Plan 9 mk is better than make
 
 Way back in the 90s, some smart guys at Bell Labs got together and decided to
@@ -105,6 +110,12 @@ mean.txt:Sjulia: input.txt
 
 Functional, but with some bugs and some unimplemented minor features. Give it a
 try and see what you think!
+
+## Building and installing from source
+
+ * clone the repo
+ * `go build` - build the executable
+ * `go test` - run the tests
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ is for anyone who loves make, but hates all its stupid bullshit.
 ### Building/installing from source
 
  1. `git clone` the repo
- 2. `go build`
+ 2. `go get`
+ 3. `go build`
 
 ## Why Plan 9 mk is better than make
 

--- a/mk.go
+++ b/mk.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+    "runtime"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -311,7 +312,7 @@ func main() {
 	flag.BoolVar(&dryrun, "n", false, "print commands without actually executing")
 	flag.BoolVar(&shallowrebuild, "r", false, "force building of just targets")
 	flag.BoolVar(&rebuildall, "a", false, "force building of all dependencies")
-	flag.IntVar(&subprocsAllowed, "p", 4, "maximum number of jobs to execute in parallel")
+	flag.IntVar(&subprocsAllowed, "p", runtime.NumCPU(), "maximum number of jobs to execute in parallel")
 	flag.BoolVar(&interactive, "i", false, "prompt before executing rules")
 	flag.BoolVar(&quiet, "q", false, "don't print recipes before executing them")
 	flag.Parse()

--- a/mk.go
+++ b/mk.go
@@ -1,19 +1,21 @@
 package main
 
 import (
-	"bufio"
+    "bufio"
     "runtime"
-	"flag"
-	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"strings"
-	"sync"
+    "flag"
+    "fmt"
+    "io/ioutil"
+    "os"
+    "path/filepath"
+    "strings"
+    "sync"
+    "github.com/mattn/go-isatty"
 )
 
 // True if messages should be printed without fancy colors.
-var nocolor bool = false
+//  - By default, if the output stream is not the terminal, colors are disabled
+var nocolor bool = !isatty.IsTerminal(os.Stdout.Fd())
 
 // True if we are ignoring timestamps and rebuilding everything.
 var rebuildall bool = false


### PR DESCRIPTION
This pull-request makes the following updates:
- Fix issue #4 by setting nocolor's default value based on the stdout atty value.  This introduces a new dependency on [go-isatty](https://github.com/mattn/go-isatty).
- Set the default parallel number to Go's runtime `NumCPU`
- Add a general `.gitignore` for the project.
- Fix a typo in the README; Set headers semantically (they're all about the same topic, Mk)
