### PR TITLE
Some fixes and new features for complex mkfiles

### DIFF
--- a/mk.go
+++ b/mk.go
@@ -24,7 +24,9 @@ var rebuildtargets map[string]bool = make(map[string]bool)
 var mkMsgMutex sync.Mutex
 
 // The maximum number of times an rule may be applied.
-const maxRuleCnt = 1
+// This limits recursion of both meta- and non-meta-rules!
+// Maybe, this shouldn't affect meta-rules?!
+var maxRuleCnt int = 1
 
 // Limit the number of recipes executed simultaneously.
 var subprocsAllowed int
@@ -312,6 +314,7 @@ func main() {
 	flag.BoolVar(&shallowrebuild, "r", false, "force building of just targets")
 	flag.BoolVar(&rebuildall, "a", false, "force building of all dependencies")
 	flag.IntVar(&subprocsAllowed, "p", 4, "maximum number of jobs to execute in parallel")
+	flag.IntVar(&maxRuleCnt, "l", 1, "maximum number of times a specific rule can be applied (recursion)")
 	flag.BoolVar(&interactive, "i", false, "prompt before executing rules")
 	flag.BoolVar(&quiet, "q", false, "don't print recipes before executing them")
 	flag.Parse()

--- a/parse.go
+++ b/parse.go
@@ -118,7 +118,7 @@ func parsePipeInclude(p *parser, t token) parserStateFun {
 			args[i] = p.tokenbuf[i].val
 		}
 
-		output, success := subprocess("sh", args, "", true)
+		output, success := subprocess("sh", args, nil, "", true)
 		if !success {
 			p.basicErrorAtToken("subprocess include failed", t)
 		}

--- a/recipe.go
+++ b/recipe.go
@@ -106,6 +106,7 @@ func dorecipe(target string, u *node, e *edge, dryrun bool) bool {
 	_, success := subprocess(
 		sh,
 		args,
+		nil,
 		input,
 		false)
 
@@ -127,6 +128,7 @@ func dorecipe(target string, u *node, e *edge, dryrun bool) bool {
 //
 func subprocess(program string,
 	args []string,
+	env []string,
 	input string,
 	capture_out bool) (string, bool) {
 	program_path, err := exec.LookPath(program)
@@ -142,7 +144,7 @@ func subprocess(program string,
 		log.Fatal(err)
 	}
 
-	attr := os.ProcAttr{Files: []*os.File{stdin_pipe_read, os.Stdout, os.Stderr}}
+	attr := os.ProcAttr{Env: env, Files: []*os.File{stdin_pipe_read, os.Stdout, os.Stderr}}
 
 	output := make([]byte, 0)
 	capture_done := make(chan bool)


### PR DESCRIPTION
- Fixes an endless loop case in `expandDoubleQuoted` that is encountered if the position of an escape char found in the current substring is less than the position of any other escape char before the current position. The `j` variable was used as the absolute start for the substring and then replaced with the first relative position of the search char in this substring, so in every turn `j` actually is the relative position but  it was used as the absolute start for the new substring. As already mentioned, this leads to an endless loop.
- Added a feature for escaped newlines, which removes the escape and newline chars out of the expansion. It could possibly be done by only removing the escape char and keep the newline in the expansion, but I don't have a test case where the newline really needs to be kept. But in all my tests the escaped newline really needs a translation and not totally left untranslated with the escape char in the expansion. Probably, the escape char should be removed in all escape sequences and never kept in the expansion?
  I don't know the spec to answer such questions.
- Added a feature for the expansion of back quotes, which adds the currently set _`mkfile`_ variables to the environment variables of the new process. The environment variables of the current process are not touched in any way.
- Added a command line option _`-l`_ to configure the limit of the recursive rule application. Obviously, the constant 1 was not enough.

To test all theses things I tried to build the [sml-toolkit](http://www.cs.tufts.edu/~nr/toolkit/index.html). The version 0.5a can be downloaded [here](http://www.cs.tufts.edu/~nr/toolkit/v0.5a.tar.gz).
