### PR TITLE
Execute arbitrary commands in redirect inclusion

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -113,9 +113,10 @@ func parsePipeInclude(p *parser, t token) parserStateFun {
 			p.basicErrorAtToken("empty pipe include", t)
 		}
 
-		args := make([]string, len(p.tokenbuf))
+		args := make([]string, len(p.tokenbuf) + 1)
+		args[0] = "-c"
 		for i := 0; i < len(p.tokenbuf); i++ {
-			args[i] = p.tokenbuf[i].val
+			args[i + 1] = p.tokenbuf[i].val
 		}
 
 		output, success := subprocess("sh", args, "", true)


### PR DESCRIPTION
The current implementation of `<|` does not handle arbitrary commands,
like e.g. the `$PLAN9/src/mkhdr` file:

    <| cat $PLAN9/config 2>/dev/null || true

Signed-off-by: Florian Limberger <flo@purplekraken.com>